### PR TITLE
[BugFix] axios라이브러리 package.json에 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@progress/kendo-react-inputs": "^2.7.1",
     "@progress/kendo-react-intl": "^2.7.1",
     "@progress/kendo-theme-default": "^3.3.1",
+    "axios": "^0.18.0",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "react-scripts": "2.1.8"


### PR DESCRIPTION
- package.json파일에 앱 dependencies중 하나인 axios가 빠져있습니다.
- 따라서 npm install을 할 경우 axios가 설치되지않아 에러가 발생합니다.
- .gitignore 파일에 node_modules 추가